### PR TITLE
Upgrade to rundeck 4.1 & add arm64 support

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -75,6 +75,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -147,6 +147,7 @@ VOLUME ["/var/lib/rundeck/data", "/var/lib/rundeck/logs", "/var/rundeck", "/var/
 # Add config files
 COPY run.sh /run.sh
 COPY ansible-bootstrap/ /ansible-bootstrap/
+COPY run-h2-v2-migration.sh /run-h2-v2-migration.sh
 
 ENV RD_URL http://localhost:4440
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN set -x \
   && ( cd /tmp; sha256sum -c SHA256SUM || ( echo "Expected $(sha256sum awscli-bundle-${AWS_CLI_VERSION}.zip)"; exit 1; )) \
   && unzip awscli-bundle-${AWS_CLI_VERSION}.zip \
   && /tmp/awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws \
+  && rm -rf /tmp/awscli-bundle /tmp/awscli-bundle-${AWS_CLI_VERSION}.zip \
   && apt-get -y remove unzip \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
@@ -61,7 +62,7 @@ RUN set -x \
   ;
 
 # Install Rundeck
-ENV RUNDECK_VERSION=4.0.1.20220404-1_all RUNDECK_CHECKSUM=89df16e165ea826b8e99e0b9216d9247636fba9f9c199f393f56b74d58b06d7c
+ENV RUNDECK_VERSION=4.1.0.20220420-1_all RUNDECK_CHECKSUM=88610e427d0fb959c2eeb47eca948f93fd09ff43db025d9c59a232d31d989df2
 RUN set -x \
   && wget --no-verbose -O /tmp/rundeck_${RUNDECK_VERSION}.deb "https://packagecloud.io/pagerduty/rundeck/packages/any/any/rundeck_${RUNDECK_VERSION}.deb/download.deb" \
   && echo "${RUNDECK_CHECKSUM}  rundeck_${RUNDECK_VERSION}.deb" > /tmp/SHA256SUM \
@@ -70,10 +71,12 @@ RUN set -x \
   && chown -R root:rundeck /etc/rundeck \
   && chmod -R 640 /etc/rundeck/* \
   && rm -f /tmp/rundeck_${RUNDECK_VERSION}.deb /tmp/SHA256SUM \
+  && mkdir /tmp/rundeck \
+  && chown rundeck:rundeck /tmp/rundeck \
   ;
 
 # Install Rundeck CLI
-ENV RUNDECK_CLI_VERSION=1.3.11-1_all RUNDECK_CLI_CHECKSUM=ad0623ba26aeaf98c27147766f1d1c167b64cd748e88f14c7a06312be784ee8f
+ENV RUNDECK_CLI_VERSION=2.0.4-1_all RUNDECK_CLI_CHECKSUM=987a4b36870a0b0fd6a04f595ba5b179103370e5da7106cd881a8e4caec9fa11
 RUN set -x \
   && wget --no-verbose -O /tmp/rundeck_${RUNDECK_CLI_VERSION}.deb "https://packagecloud.io/pagerduty/rundeck/packages/any/any/rundeck-cli_${RUNDECK_CLI_VERSION}.deb/download.deb" \
   && echo "${RUNDECK_CLI_CHECKSUM}  rundeck_${RUNDECK_CLI_VERSION}.deb" > /tmp/SHA256SUM \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,9 +51,16 @@ RUN set -x \
   ;
 
 # Install Dumb-init
-ENV DUMB_INIT_VERSION=1.2.5 DUMB_INIT_CHECKSUM=e874b55f3279ca41415d290c512a7ba9d08f98041b28ae7c2acb19a545f1c4df
+ENV DUMB_INIT_VERSION=1.2.5 \
+    DUMB_INIT_CHECKSUM_X86_64=e874b55f3279ca41415d290c512a7ba9d08f98041b28ae7c2acb19a545f1c4df \
+    DUMB_INIT_CHECKSUM_AARCH64=b7d648f97154a99c539b63c55979cd29f005f88430fb383007fe3458340b795e
 RUN set -x \
-  && wget --no-verbose https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_x86_64 -O /tmp/dumb-init \
+  && if [ "$(uname -m)" = "x86_64" ] ; then \
+        DUMB_INIT_CHECKSUM="${DUMB_INIT_CHECKSUM_X86_64}"; \
+      elif [ "$(uname -m)" = "aarch64" ]; then \
+        DUMB_INIT_CHECKSUM="${DUMB_INIT_CHECKSUM_AARCH64}"; \
+      fi \
+  && wget --no-verbose https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_$(uname -m) -O /tmp/dumb-init \
   && echo "${DUMB_INIT_CHECKSUM}  dumb-init" > /tmp/SHA256SUM \
   && ( cd /tmp; sha256sum -c SHA256SUM || ( echo "Expected $(sha256sum dumb-init)"; exit 1; )) \
   && mv /tmp/dumb-init /usr/local/bin/ \

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ DOCKER_VOLUMES := -v $(shell pwd)/test/config/:/config \
 
 .PHONY: *
 build:
-	docker build --platform linux/amd64 --pull --cache-from ${REGISTRY}/${IMAGE_NAME}:latest -t ${IMAGE_NAME}:${TAG} .
+	docker build --pull --cache-from ${REGISTRY}/${IMAGE_NAME}:latest -t ${IMAGE_NAME}:${TAG} .
 
 build-dev:
-	docker build --platform linux/amd64 --pull -t ${IMAGE_NAME}:${TAG} .
+	docker build --pull -t ${IMAGE_NAME}:${TAG} .
 
 bash:
 	docker run --rm -it --name rundeck -p 4440:4440 $(DOCKER_VOLUMES) --entrypoint /bin/bash ${IMAGE_NAME}:${TAG}

--- a/ansible-bootstrap/templates/rundeck-config.properties.j2
+++ b/ansible-bootstrap/templates/rundeck-config.properties.j2
@@ -6,8 +6,9 @@ rdeck.base=/var/lib/rundeck
 rss.enabled=false
 # change hostname here
 grails.serverURL={{ rundeck_server_url }}
-dataSource.dbCreate = update
+dataSource.dbCreate = none
 dataSource.url = jdbc:h2:file:/var/lib/rundeck/data/rundeckdb;NON_KEYWORDS=MONTH,HOUR,MINUTE,YEAR,SECONDS;DB_CLOSE_ON_EXIT=FALSE
+grails.plugin.databasemigration.updateOnStart=true
 
 rundeck.api.tokens.duration.max={{ rundeck_api_auth_max_duration | default("30d") }}
 

--- a/ansible-bootstrap/templates/rundeck-config.properties.j2
+++ b/ansible-bootstrap/templates/rundeck-config.properties.j2
@@ -7,7 +7,7 @@ rss.enabled=false
 # change hostname here
 grails.serverURL={{ rundeck_server_url }}
 dataSource.dbCreate = update
-dataSource.url = jdbc:h2:file:/var/lib/rundeck/data/rundeckdb;MVCC=true
+dataSource.url = jdbc:h2:file:/var/lib/rundeck/data/rundeckdb;NON_KEYWORDS=MONTH,HOUR,MINUTE,YEAR,SECONDS;DB_CLOSE_ON_EXIT=FALSE
 
 rundeck.api.tokens.duration.max={{ rundeck_api_auth_max_duration | default("30d") }}
 

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -15,37 +15,45 @@ trap finish EXIT
 cd "${TEMP_DIR}"
 echo "PWD: $(pwd)"
 
+# Get the arch
+ARCH="$(uname -m)"
+# These variables are used to convert from `uname -m` output to expected arch names.
+# If a particular tool uses different names these variables can also be added to that tools function and updated to the tool specific values.
+# When adding these variables to a tools function remember to add `aarch64 x86_64` to that functions `local` variables list.
+aarch64="arm64"
+x86_64="amd64"
+
 install_sops() {
   local version checksum checksum_var
   version="${1}"
-  checksum_var="SOPS_${version//\./_}_CHECKSUM"
+  checksum_var="SOPS_${version//\./_}_CHECKSUM_${ARCH^^}"
   checksum="${!checksum_var}"
 
-  echo "https://github.com/mozilla/sops/releases/download/v${version}/sops-v${version}.linux"
+  echo "https://github.com/mozilla/sops/releases/download/v${version}/sops-v${version}.linux.${!ARCH}"
   echo "${checksum}"
 
-  wget -nv "https://github.com/mozilla/sops/releases/download/v${version}/sops-v${version}.linux"
-  echo "${checksum}  sops-v${version}.linux" > SHA256SUM
-  sha256sum -c SHA256SUM || ( echo "Expected $(sha256sum sops-v${version}.linux)"; exit 1; )
+  wget -nv "https://github.com/mozilla/sops/releases/download/v${version}/sops-v${version}.linux.${!ARCH}"
+  echo "${checksum}  sops-v${version}.linux.${!ARCH}" > SHA256SUM
+  sha256sum -c SHA256SUM || ( echo "Expected $(sha256sum sops-v${version}.linux.${!ARCH})"; exit 1; )
 
-  install -o root -g root -m 755 "sops-v${version}.linux" /opt/bin/sops
-  rm "sops-v${version}.linux"
+  install -o root -g root -m 755 "sops-v${version}.linux.${!ARCH}" /opt/bin/sops
+  rm "sops-v${version}.linux.${!ARCH}"
 }
 
 install_lego() {
   local version checksum checksum_var
   version="${1}"
-  checksum_var="LEGO_${version//\./_}_CHECKSUM"
+  checksum_var="LEGO_${version//\./_}_CHECKSUM_${ARCH^^}"
   checksum="${!checksum_var}"
 
-  echo "https://github.com/xenolf/lego/releases/download/v${version}/lego_v${version}_linux_amd64.tar.gz"
+  echo "https://github.com/xenolf/lego/releases/download/v${version}/lego_v${version}_linux_${!ARCH}.tar.gz"
   echo "${checksum}"
 
-  wget -nv "https://github.com/xenolf/lego/releases/download/v${version}/lego_v${version}_linux_amd64.tar.gz"
-  echo "${checksum}  lego_v${version}_linux_amd64.tar.gz" > SHA256SUM
-  sha256sum -c SHA256SUM || ( echo "Expected $(sha256sum lego_v${version}_linux_amd64.tar.gz)"; exit 1; )
+  wget -nv "https://github.com/xenolf/lego/releases/download/v${version}/lego_v${version}_linux_${!ARCH}.tar.gz"
+  echo "${checksum}  lego_v${version}_linux_${!ARCH}.tar.gz" > SHA256SUM
+  sha256sum -c SHA256SUM || ( echo "Expected $(sha256sum lego_v${version}_linux_${!ARCH}.tar.gz)"; exit 1; )
 
-  tar -zxf "lego_v${version}_linux_amd64.tar.gz" lego
+  tar -zxf "lego_v${version}_linux_${!ARCH}.tar.gz" lego
   install -o root -g root -m 755 lego /opt/bin/lego
   rm lego
 }
@@ -53,39 +61,39 @@ install_lego() {
 install_helm() {
   local version checksum checksum_var version_parts major_minor
   version="${1}"
-  checksum_var="HELM_${version//\./_}_CHECKSUM"
+  checksum_var="HELM_${version//\./_}_CHECKSUM_${ARCH^^}"
   checksum="${!checksum_var}"
 
   IFS='.' read -r -a version_parts <<<"${version}"
   major_minor="${version_parts[0]}.${version_parts[1]}"
 
-    echo "https://get.helm.sh/helm-v${version}-linux-amd64.tar.gz"
-    echo "${checksum}"
+  echo "https://get.helm.sh/helm-v${version}-linux-${!ARCH}.tar.gz"
+  echo "${checksum}"
 
-    wget -nv "https://get.helm.sh/helm-v${version}-linux-amd64.tar.gz"
-  echo "${checksum}  helm-v${version}-linux-amd64.tar.gz" > SHA256SUM
-  sha256sum -c SHA256SUM || ( echo "Expected $(sha256sum helm-v${version}-linux-amd64.tar.gz)"; exit 1; )
+  wget -nv "https://get.helm.sh/helm-v${version}-linux-${!ARCH}.tar.gz"
+  echo "${checksum}  helm-v${version}-linux-${!ARCH}.tar.gz" > SHA256SUM
+  sha256sum -c SHA256SUM || ( echo "Expected $(sha256sum helm-v${version}-linux-${!ARCH}.tar.gz)"; exit 1; )
 
-  tar -zxf "helm-v${version}-linux-amd64.tar.gz" linux-amd64/helm
+  tar -zxf "helm-v${version}-linux-${!ARCH}.tar.gz" linux-${!ARCH}/helm
 
   mkdir -p "/opt/helm-${major_minor}/bin"
-  install -o root -g root -m 755 linux-amd64/helm "/opt/helm-${major_minor}/bin/helm"
-  rm linux-amd64/helm
+  install -o root -g root -m 755 linux-${!ARCH}/helm "/opt/helm-${major_minor}/bin/helm"
+  rm linux-${!ARCH}/helm
 }
 
 install_kubectl() {
   local version checksum checksum_var version_parts major_minor
   version="${1}"
-  checksum_var="KUBECTL_${version//\./_}_CHECKSUM"
+  checksum_var="KUBECTL_${version//\./_}_CHECKSUM_${ARCH^^}"
   checksum="${!checksum_var}"
 
   IFS='.' read -r -a version_parts <<<"${version}"
   major_minor="${version_parts[0]}.${version_parts[1]}"
 
-  echo "https://storage.googleapis.com/kubernetes-release/release/v${version}/bin/linux/amd64/kubectl"
+  echo "https://storage.googleapis.com/kubernetes-release/release/v${version}/bin/linux/${!ARCH}/kubectl"
   echo "${checksum}"
 
-  wget -nv "https://storage.googleapis.com/kubernetes-release/release/v${version}/bin/linux/amd64/kubectl"
+  wget -nv "https://storage.googleapis.com/kubernetes-release/release/v${version}/bin/linux/${!ARCH}/kubectl"
   echo "${checksum}  kubectl" > SHA256SUM
   sha256sum kubectl
   sha256sum -c SHA256SUM || ( echo "Expected $(sha256sum kubectl)"; exit 1; )
@@ -98,54 +106,64 @@ install_kubectl() {
 install_argo() {
   local version checksum checksum_var version_parts major_minor
   version="${1}"
-  checksum_var="ARGO_${version//\./_}_CHECKSUM"
+  checksum_var="ARGO_${version//\./_}_CHECKSUM_${ARCH^^}"
   checksum="${!checksum_var}"
 
   IFS='.' read -r -a version_parts <<<"${version}"
   major_minor="${version_parts[0]}.${version_parts[1]}"
 
-  echo "https://github.com/argoproj/argo-workflows/releases/download/v${version}/argo-linux-amd64.gz"
+  echo "https://github.com/argoproj/argo-workflows/releases/download/v${version}/argo-linux-${!ARCH}.gz"
   echo "${checksum}"
 
-  wget -nv "https://github.com/argoproj/argo-workflows/releases/download/v${version}/argo-linux-amd64.gz"
-  echo "${checksum}  argo-linux-amd64.gz" > SHA256SUM
-  sha256sum -c SHA256SUM || ( echo "Expected $(sha256sum argo-linux-amd64.gz)"; exit 1; )
+  wget -nv "https://github.com/argoproj/argo-workflows/releases/download/v${version}/argo-linux-${!ARCH}.gz"
+  echo "${checksum}  argo-linux-${!ARCH}.gz" > SHA256SUM
+  sha256sum -c SHA256SUM || ( echo "Expected $(sha256sum argo-linux-${!ARCH}.gz)"; exit 1; )
 
-  gunzip argo-linux-amd64.gz
+  gunzip argo-linux-${!ARCH}.gz
   mkdir -p "/opt/argo-${major_minor}/bin"
-  install -o root -g root -m 755 argo-linux-amd64 "/opt/argo-${major_minor}/bin/argo"
-  rm argo-linux-amd64
+  install -o root -g root -m 755 argo-linux-${!ARCH} "/opt/argo-${major_minor}/bin/argo"
+  rm argo-linux-${!ARCH}
 }
 
 # Versions
+# Both the amd64 and arm64 checksums must be included here.
 
-KUBECTL_1_26_3_CHECKSUM=026c8412d373064ab0359ed0d1a25c975e9ce803a093d76c8b30c5996ad73e75
-KUBECTL_1_25_8_CHECKSUM=80e70448455f3d19c3cb49bd6ff6fc913677f4f240d368fa2b9f0d400c8cd16e
-KUBECTL_1_24_12_CHECKSUM=25875551d4242339bcc8cef0c18f0a0f631ea621f6fab1190a5aaab466634e7c
-KUBECTL_1_23_17_CHECKSUM=f09f7338b5a677f17a9443796c648d2b80feaec9d6a094ab79a77c8a01fde941
-KUBECTL_1_22_4_CHECKSUM=21f24aa723002353eba1cc2668d0be22651f9063f444fd01626dce2b6e1c568c
-KUBECTL_1_21_3_CHECKSUM=631246194fc1931cb897d61e1d542ef2321ec97adcb859a405d3b285ad9dd3d6
-KUBECTL_1_20_9_CHECKSUM=9d76c4431e10e268dd7c6b53b27aaa62a6f26455013e1d7f6d85da86003539b9
-KUBECTL_1_19_13_CHECKSUM=275a97f2c825e8148b46b5b7eb62c1c76bdbadcca67f5e81f19a5985078cc185
-KUBECTL_1_18_20_CHECKSUM=66a9bb8e9843050340844ca6e72e67632b75b9ebb651559c49db22f35450ed2f
+KUBECTL_1_26_3_CHECKSUM_X86_64=026c8412d373064ab0359ed0d1a25c975e9ce803a093d76c8b30c5996ad73e75
+KUBECTL_1_26_3_CHECKSUM_AARCH64=0f62cbb6fafa109f235a08348d74499a57bb294c2a2e6ee34be1fa83432fec1d
+KUBECTL_1_25_8_CHECKSUM_X86_64=80e70448455f3d19c3cb49bd6ff6fc913677f4f240d368fa2b9f0d400c8cd16e
+KUBECTL_1_25_8_CHECKSUM_AARCH64=28cf5f666cb0c11a8a2b3e5ae4bf93e56b74ab6051720c72bb231887bfc1a7c6
+KUBECTL_1_24_12_CHECKSUM_X86_64=25875551d4242339bcc8cef0c18f0a0f631ea621f6fab1190a5aaab466634e7c
+KUBECTL_1_24_12_CHECKSUM_AARCH64=a945095ceabc2b6f943c8c7c8484925b1b205738231fe7d34368a3e77dfe319b
+KUBECTL_1_23_17_CHECKSUM_X86_64=f09f7338b5a677f17a9443796c648d2b80feaec9d6a094ab79a77c8a01fde941
+KUBECTL_1_23_17_CHECKSUM_AARCH64=c4a48fdc6038beacbc5de3e4cf6c23639b643e76656aabe2b7798d3898ec7f05
+KUBECTL_1_22_4_CHECKSUM_X86_64=21f24aa723002353eba1cc2668d0be22651f9063f444fd01626dce2b6e1c568c
+KUBECTL_1_22_4_CHECKSUM_AARCH64=3fcec0284c0fdfc22e89a5b73ebd7f51120cc3505a11a4f6d6f819d46a40b26a
+KUBECTL_1_21_3_CHECKSUM_X86_64=631246194fc1931cb897d61e1d542ef2321ec97adcb859a405d3b285ad9dd3d6
+KUBECTL_1_21_3_CHECKSUM_AARCH64=2be58b5266faeeb93f38fa72d36add13a950643d2ae16a131f48f5a21c66ef23
 
-HELM_3_11_2_CHECKSUM=781d826daec584f9d50a01f0f7dadfd25a3312217a14aa2fbb85107b014ac8ca
-HELM_3_10_3_CHECKSUM=950439759ece902157cf915b209b8d694e6f675eaab5099fb7894f30eeaee9a2
-HELM_3_9_4_CHECKSUM=31960ff2f76a7379d9bac526ddf889fb79241191f1dbe2a24f7864ddcb3f6560
-HELM_3_8_2_CHECKSUM=6cb9a48f72ab9ddfecab88d264c2f6508ab3cd42d9c09666be16a7bf006bed7b
-HELM_3_7_2_CHECKSUM=4ae30e48966aba5f807a4e140dad6736ee1a392940101e4d79ffb4ee86200a9e
-HELM_3_6_3_CHECKSUM=07c100849925623dc1913209cd1a30f0a9b80a5b4d6ff2153c609d11b043e262
-HELM_3_5_4_CHECKSUM=a8ddb4e30435b5fd45308ecce5eaad676d64a5de9c89660b56face3fe990b318
-HELM_3_4_2_CHECKSUM=cacde7768420dd41111a4630e047c231afa01f67e49cc0c6429563e024da4b98
-HELM_3_3_4_CHECKSUM=b664632683c36446deeb85c406871590d879491e3de18978b426769e43a1e82c
-HELM_3_2_4_CHECKSUM=8eb56cbb7d0da6b73cd8884c6607982d0be8087027b8ded01d6b2759a72e34b1
+HELM_3_11_2_CHECKSUM_X86_64=781d826daec584f9d50a01f0f7dadfd25a3312217a14aa2fbb85107b014ac8ca
+HELM_3_11_2_CHECKSUM_AARCH64=0a60baac83c3106017666864e664f52a4e16fbd578ac009f9a85456a9241c5db
+HELM_3_10_3_CHECKSUM_X86_64=950439759ece902157cf915b209b8d694e6f675eaab5099fb7894f30eeaee9a2
+HELM_3_10_3_CHECKSUM_AARCH64=260cda5ff2ed5d01dd0fd6e7e09bc80126e00d8bdc55f3269d05129e32f6f99d
+HELM_3_9_4_CHECKSUM_X86_64=31960ff2f76a7379d9bac526ddf889fb79241191f1dbe2a24f7864ddcb3f6560
+HELM_3_9_4_CHECKSUM_AARCH64=d24163e466f7884c55079d1050968e80a05b633830047116cdfd8ae28d35b0c0
+HELM_3_8_2_CHECKSUM_X86_64=6cb9a48f72ab9ddfecab88d264c2f6508ab3cd42d9c09666be16a7bf006bed7b
+HELM_3_8_2_CHECKSUM_AARCH64=238db7f55e887f9c1038b7e43585b84389a05fff5424e70557886cad1635b3ce
+HELM_3_7_2_CHECKSUM_X86_64=4ae30e48966aba5f807a4e140dad6736ee1a392940101e4d79ffb4ee86200a9e
+HELM_3_7_2_CHECKSUM_AARCH64=b0214eabbb64791f563bd222d17150ce39bf4e2f5de49f49fdb456ce9ae8162f
+HELM_3_6_3_CHECKSUM_X86_64=07c100849925623dc1913209cd1a30f0a9b80a5b4d6ff2153c609d11b043e262
+HELM_3_6_3_CHECKSUM_AARCH64=6fe647628bc27e7ae77d015da4d5e1c63024f673062ac7bc11453ccc55657713
 
-SOPS_3_7_3_CHECKSUM=53aec65e45f62a769ff24b7e5384f0c82d62668dd96ed56685f649da114b4dbb
+SOPS_3_7_3_CHECKSUM_X86_64=53aec65e45f62a769ff24b7e5384f0c82d62668dd96ed56685f649da114b4dbb
+SOPS_3_7_3_CHECKSUM_AARCH64=4945313ed0dfddba52a12ab460d750c91ead725d734039493da0285ad6c5f032
 
-LEGO_4_4_0_CHECKSUM=302a780a56dd52601aa5d1dc31e607599cb85b113830abe464001622ca8b80a2
+LEGO_4_4_0_CHECKSUM_X86_64=302a780a56dd52601aa5d1dc31e607599cb85b113830abe464001622ca8b80a2
+LEGO_4_4_0_CHECKSUM_AARCH64=abe0e795be083143bc72ffe0f62670d96d1d33caeec2649b452d6fe9ac7ede4f
 
-ARGO_3_1_5_CHECKSUM=68ebb30e79aa5ab649dbd0feb6e227b0dcff2b2983c00e176cc523a9f883567b
-ARGO_3_4_5_CHECKSUM=0528ff0c0aa87a3f150376eee2f1b26e8b41eb96578c43d715c906304627d3a1
+ARGO_3_1_5_CHECKSUM_X86_64=68ebb30e79aa5ab649dbd0feb6e227b0dcff2b2983c00e176cc523a9f883567b
+ARGO_3_1_5_CHECKSUM_AARCH64=dc3c36081b6b49c8977dcffa9393a29e83568fba36a35f472caaac108674c03e
+ARGO_3_4_5_CHECKSUM_X86_64=0528ff0c0aa87a3f150376eee2f1b26e8b41eb96578c43d715c906304627d3a1
+ARGO_3_4_5_CHECKSUM_AARCH64=6d953f667ded668f351bfeb94f32e34b70badc23770c11b55e3d2bc32caa274c
 
 install_sops 3.7.3
 

--- a/run-h2-v2-migration.sh
+++ b/run-h2-v2-migration.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Script to run the h2 v2 migration from https://github.com/rundeck-plugins/h2-v2-migration
+# This script needs to be run from within a rundeck container with all volumes mounted as usual
+
+set -euo pipefail
+IFS=$'\n\t'
+
+git -C /var/lib/rundeck/data clone https://github.com/rundeck-plugins/h2-v2-migration.git
+
+mkdir /var/lib/rundeck/data/h2-v2-migration/backup
+
+cp /var/lib/rundeck/data/rundeckdb.* /var/lib/rundeck/data/h2-v2-migration/backup/
+
+sed -i 's/grailsdb/rundeckdb/g' /var/lib/rundeck/data/h2-v2-migration/migration.sh
+
+(
+  cd /var/lib/rundeck/data/h2-v2-migration
+  /var/lib/rundeck/data/h2-v2-migration/migration.sh -f /var/lib/rundeck/data/h2-v2-migration/backup/rundeckdb -u sa
+)
+
+cp /var/lib/rundeck/data/h2-v2-migration/output/v2/data/rundeckdb.mv.db /var/lib/rundeck/data/rundeckdb.mv.db
+
+chown rundeck:rundeck /var/lib/rundeck/data/rundeckdb.mv.db

--- a/run-h2-v2-migration.sh
+++ b/run-h2-v2-migration.sh
@@ -5,6 +5,8 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+set -x
+
 git -C /var/lib/rundeck/data clone https://github.com/rundeck-plugins/h2-v2-migration.git
 
 mkdir /var/lib/rundeck/data/h2-v2-migration/backup


### PR DESCRIPTION
This upgrades Rundeck to version 4.1. It includes a script to perform the h2 v2 upgrade.

Additionally arm64 support is added.